### PR TITLE
Fix layout of search results page

### DIFF
--- a/template/search_results.html
+++ b/template/search_results.html
@@ -141,8 +141,10 @@
 
 						</div>
 					</dd>
-					<dd class="posts">{searchresults.TOPIC_REPLIES} <dfn>{L_REPLIES}</dfn></dd>
-					<dd class="views">{searchresults.TOPIC_VIEWS} <dfn>{L_VIEWS}</dfn></dd>
+					<dd class="posts">
+						{L_REPLIES}: <strong>{searchresults.TOPIC_REPLIES}</strong><br />
+						{L_VIEWS}: <strong>{searchresults.TOPIC_VIEWS}</strong>
+					</dd>
 					<dd class="lastpost">
 						<span><dfn>{L_LAST_POST} </dfn>{L_POST_BY_AUTHOR} {searchresults.LAST_POST_AUTHOR_FULL}
 							<!-- IF not S_IS_BOT -->


### PR DESCRIPTION
The fix layout of the status column (e.g. for unread posts search, or active topics)
to match the layout of the viewforum page.